### PR TITLE
Exclude firefox rpm

### DIFF
--- a/gen_workstation.sh
+++ b/gen_workstation.sh
@@ -48,7 +48,10 @@ do
   cat << EOF >> Containerfile
 RUN mkdir /var/roothome
 
-RUN dnf group install -y "${group}" --exclude=firefox && \
+RUN dnf group install -y \
+      "${group}" \
+      --exclude=firefox \
+      --exclude=firefox-langpacks && \
     dnf clean all && \
     rm -Rf /var/roothome
 


### PR DESCRIPTION
This allows for the flatpak to be used instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container images no longer include Firefox or its language packs by default, reducing image size and unnecessary packages.
  * Build/downloads are faster and more efficient due to the exclusion.
  * Slightly lowers attack surface and resource usage in dev/test environments.
  * No workflow changes required; install a browser explicitly or use an external browser if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->