### PR TITLE
Use /mnt for container storage

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -46,8 +46,11 @@ jobs:
         run: |
           df -h
           sudo mv /var/lib/containers/storage /var/lib/containers/storage.orig
-          sudo mkdir /mnt/containers
+          mv ~/.local/share/containers/storage ~/.local/share/containers/storage.orig
+          sudo mkdir /mnt/containers /mnt/usr_containers
+          sudo chown $USER /mnt/usr_containers
           sudo ln -s /mnt/containers /var/lib/containers/storage
+          ln -s /mnt/usr_containers ~/.local/share/containers/storage
           
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           df -h
           sudo mv /var/lib/containers/storage /var/lib/containers/storage.orig
-          mv ~/.local/share/containers/storage ~/.local/share/containers/storage.orig
+          # mv ~/.local/share/containers/storage ~/.local/share/containers/storage.orig
           sudo mkdir /mnt/containers /mnt/usr_containers
           sudo chown $USER /mnt/usr_containers
           sudo ln -s /mnt/containers /var/lib/containers/storage

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -114,6 +114,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Show remaining space
+        if: always()
+        run: |
+          df -h
+
   combine-tags:
     name: Combine Tags
     strategy:

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -42,6 +42,13 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
+      - name: Replace container storage with /mnt
+        run: |
+          df -h
+          sudo mv /var/lib/containers/storage /var/lib/containers/storage.orig
+          sudo mkdir /mnt/containers
+          ln -s /mnt/containers /var/lib/containers/storage
+          
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -49,21 +56,21 @@ jobs:
           fetch-depth: 0
           fetch-tags: 'true'
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-          
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
+      #- name: Free Disk Space (Ubuntu)
+      #  uses: jlumbroso/free-disk-space@v1.3.1
+      #  with:
+      #    # this might remove tools that are actually needed,
+      #    # if set to "true" but frees about 6 GB
+      #    tool-cache: false
+      #    
+      #    # all of these default to true, but feel free to set to
+      #    # "false" if necessary for your workflow
+      #    android: true
+      #    dotnet: true
+      #    haskell: true
+      #    large-packages: true
+      #    docker-images: true
+      #    swap-storage: true
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -50,6 +50,7 @@ jobs:
           sudo mkdir /mnt/containers /mnt/usr_containers
           sudo chown $USER /mnt/usr_containers
           sudo ln -s /mnt/containers /var/lib/containers/storage
+          mkdir -p ~/.local/share/containers
           ln -s /mnt/usr_containers ~/.local/share/containers/storage
           
       - name: Checkout

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -47,7 +47,7 @@ jobs:
           df -h
           sudo mv /var/lib/containers/storage /var/lib/containers/storage.orig
           sudo mkdir /mnt/containers
-          ln -s /mnt/containers /var/lib/containers/storage
+          sudo ln -s /mnt/containers /var/lib/containers/storage
           
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -45,11 +45,17 @@ jobs:
       - name: Replace container storage with /mnt
         run: |
           df -h
-          sudo mv /var/lib/containers/storage /var/lib/containers/storage.orig
-          # mv ~/.local/share/containers/storage ~/.local/share/containers/storage.orig
+          # Make /mnt directories
           sudo mkdir /mnt/containers /mnt/usr_containers
+          
+          # Set permissions for non-root container storage
           sudo chown $USER /mnt/usr_containers
+          
+          # Replace root container storage
+          sudo mv /var/lib/containers/storage /var/lib/containers/storage.orig
           sudo ln -s /mnt/containers /var/lib/containers/storage
+          
+          # Replace user container storage
           mkdir -p ~/.local/share/containers
           ln -s /mnt/usr_containers ~/.local/share/containers/storage
           
@@ -59,22 +65,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
           fetch-tags: 'true'
-
-      #- name: Free Disk Space (Ubuntu)
-      #  uses: jlumbroso/free-disk-space@v1.3.1
-      #  with:
-      #    # this might remove tools that are actually needed,
-      #    # if set to "true" but frees about 6 GB
-      #    tool-cache: false
-      #    
-      #    # all of these default to true, but feel free to set to
-      #    # "false" if necessary for your workflow
-      #    android: true
-      #    dotnet: true
-      #    haskell: true
-      #    large-packages: true
-      #    docker-images: true
-      #    swap-storage: true
 
       - name: Docker meta
         id: meta
@@ -119,7 +109,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Show remaining space
-        if: always()
+        if: failure()
         run: |
           df -h
 


### PR DESCRIPTION
The default root space is limited, but /mnt has 66G of space. Replacing `~/.local/share/containers/storage` with a link to a directory in /mnt should remove the need to cleanup space on the runner.

Does not do anything for arm builds as they do not have a `/mnt` mount point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to relocate container storage to a mounted path prior to checkout to avoid disk issues.
  * Removed the previous Free Disk Space step.
  * Added disk-usage reporting steps that run on workflow failure to show remaining space after image operations.
  * No changes to application behavior, UI, releases, installation, or usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->