### PR TITLE
Revert gnome-shell to an earlier version

### DIFF
--- a/Containerfile.gnome
+++ b/Containerfile.gnome
@@ -1,8 +1,6 @@
 # Split custom work to separate image layer
 FROM workstation
 
-COPY rootfs/ /
-
 # Install additional packages
 RUN dnf install -y \
       virt-manager \

--- a/Containerfile.xfce
+++ b/Containerfile.xfce
@@ -1,8 +1,6 @@
 # Split custom work to separate image layer
 FROM workstation
 
-COPY rootfs/ /
-
 # Install additional packages
 RUN dnf install -y \
       virt-manager \

--- a/gen_workstation.sh
+++ b/gen_workstation.sh
@@ -30,6 +30,8 @@ do
   if [[ $index -eq 1 ]]
   then
     echo "FROM ${container} AS group1" > Containerfile
+
+    echo "COPY rootfs/ /"
     
     # Install audit separately because the post-install script requires systemd.
     # It only starts the audit service, so it is not required.

--- a/gen_workstation.sh
+++ b/gen_workstation.sh
@@ -31,7 +31,7 @@ do
   then
     echo "FROM ${container} AS group1" > Containerfile
 
-    echo "COPY rootfs/ /"
+    echo "COPY rootfs/ /" >> Containerfile
     
     # Install audit separately because the post-install script requires systemd.
     # It only starts the audit service, so it is not required.

--- a/rootfs/etc/dnf/versionlock.toml
+++ b/rootfs/etc/dnf/versionlock.toml
@@ -1,0 +1,10 @@
+version = "1.0"
+
+[[packages]]
+name = "gnome-shell"
+comment = "49.5-1 crashes when a monitor is removed"
+
+[[packages.conditions]]
+key = "evr"
+comparator = "="
+value = "49.4-2.fc43"

--- a/rootfs/etc/dnf/versionlock.toml
+++ b/rootfs/etc/dnf/versionlock.toml
@@ -1,17 +1,8 @@
 version = "1.0"
 
 [[packages]]
-name = "gnome-shell"
-comment = "49.5-1 crashes when a monitor is removed"
-
-[[packages.conditions]]
-key = "evr"
-comparator = "="
-value = "49.4-2.fc43"
-
-[[packages]]
 name = "mutter"
-comment = "supposedly related to gnome-shell crash"
+comment = "causes gnome-shell to crash whenever a monitor is removed"
 
 [[packages.conditions]]
 key = "evr"

--- a/rootfs/etc/dnf/versionlock.toml
+++ b/rootfs/etc/dnf/versionlock.toml
@@ -7,7 +7,7 @@ comment = "49.5-1 crashes when a monitor is removed"
 [[packages.conditions]]
 key = "evr"
 comparator = "="
-value = "49.4-1.fc43"
+value = "49.4-2.fc43"
 
 [[packages]]
 name = "mutter"
@@ -15,5 +15,5 @@ comment = "supposedly related to gnome-shell crash"
 
 [[packages.conditions]]
 key = "evr"
-comparator = "="
-value = "49.4-1.fc43"
+comparator = "!="
+value = "49.5-1.fc43"

--- a/rootfs/etc/dnf/versionlock.toml
+++ b/rootfs/etc/dnf/versionlock.toml
@@ -8,3 +8,12 @@ comment = "49.5-1 crashes when a monitor is removed"
 key = "evr"
 comparator = "="
 value = "49.4-1.fc43"
+
+[[packages]]
+name = "mutter"
+comment = "supposedly related to gnome-shell crash"
+
+[[packages.conditions]]
+key = "evr"
+comparator = "="
+value = "49.4-1.fc43"

--- a/rootfs/etc/dnf/versionlock.toml
+++ b/rootfs/etc/dnf/versionlock.toml
@@ -7,4 +7,4 @@ comment = "49.5-1 crashes when a monitor is removed"
 [[packages.conditions]]
 key = "evr"
 comparator = "="
-value = "49.4-2.fc43"
+value = "49.4-1.fc43"


### PR DESCRIPTION
The latest version of gnome-shell crashes whenever a monitor is removed. This is very inconvenient when using a laptop with a docking station.

Attempted Combinations
| gnome-shell | mutter | result |
|--------------------|-----------|----------|
| 49.5-1             | 49.5-1  | crash |
| 49.4-2             | 49.5-1  | crash |
| 49.4-1             | 49.5-1  | crash |
| 49.4-1             | 49.4-1  | no crash |
| 49.4-2             | 49.4-1  | no crash |
| 49.5-1             | 49.4-1  | no crash |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Primary workstation build now populates the image root from local files in the initial build stage; redundant root-population steps were removed from some desktop variants.
* **Bug Fixes**
  * Locked the desktop shell/compositor package version to avoid a known crash when displays are disconnected, improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->